### PR TITLE
Stop rendering literal backticks around inline code

### DIFF
--- a/src/lib/styles/tailwind.config.js
+++ b/src/lib/styles/tailwind.config.js
@@ -24,7 +24,11 @@ export const theme = {
 					'--tw-prose-pre-code': 'inherit', // Inherit from shiki for code blocks
 					'--tw-prose-pre-bg': 'var(--color-mantle)', // Background for code blocks
 					'--tw-prose-th-borders': 'var(--color-surface1)',
-					'--tw-prose-td-borders': 'var(--color-surface0)'
+					'--tw-prose-td-borders': 'var(--color-surface0)',
+					// @tailwindcss/typography wraps inline code in literal backticks via
+					// code::before/::after. Kill them.
+					'code::before': { content: '""' },
+					'code::after': { content: '""' }
 				}
 			}
 		})


### PR DESCRIPTION
Inline code in posts rendered with literal backtick characters inside the styled box, e.g. `` `Runtime.InvalidEntrypoint` `` instead of `Runtime.InvalidEntrypoint`.

## Cause
The rendered HTML was clean (`<code>Runtime.InvalidEntrypoint</code>`). The backticks were injected by `@tailwindcss/typography`, which ships:

```css
.prose :where(code)::before { content: "`" }
.prose :where(code)::after  { content: "`" }
```

## Fix
Override both pseudo-elements to empty content in the typography config (`src/lib/styles/tailwind.config.js`).

## Verified
In a built preview, the inline `<code>` now computes `::before`/`::after` content as `""` (was `` "`" ``), and zero backtick `content` rules remain in the client CSS.

Pre-existing issue, unrelated to the Shiki size PR (#32).