### PR TITLE
Fix prerendered social image URLs

### DIFF
--- a/src/routes/posts/[slug]/+page.svelte
+++ b/src/routes/posts/[slug]/+page.svelte
@@ -4,7 +4,7 @@
 	import SlabTitle from '$components/SlabTitle.svelte';
 	import PostTags from '$components/posts/PostTags.svelte';
 	import '$lib/styles/content.css';
-	import { page } from '$app/state';
+	import Site from '$lib/config/common';
 
 	let { data }: { data: PostPageData } = $props();
 
@@ -20,16 +20,13 @@
 	<meta property="og:title" content={data.metadata.title.text} />
 	<meta property="og:description" content={data.metadata.description} />
 	{#if data.metadata.image}
-		<meta property="og:image" content={new URL(data.metadata.image.url, page.url.origin).href} />
+		<meta property="og:image" content={new URL(data.metadata.image.url, Site.url).href} />
 	{/if}
 	<meta property="og:type" content="article" />
 	<meta name="twitter:title" content={data.metadata.title.text} />
 	<meta name="twitter:description" content={data.metadata.description} />
 	{#if data.metadata.image}
-		<meta
-			name="twitter:image:src"
-			content={new URL(data.metadata.image.url, page.url.origin).href}
-		/>
+		<meta name="twitter:image:src" content={new URL(data.metadata.image.url, Site.url).href} />
 	{/if}
 </svelte:head>
 

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { IconCalendarEvent } from '@tabler/icons-svelte';
 	import type { ProjectPageData } from '$types/projects';
-	import { page } from '$app/state';
 	import { formatDate } from '$utils/date';
 	import { getIconByName } from '$lib/content/projects';
+	import Site from '$lib/config/common';
 
 	import '$lib/styles/content.css';
 	import ProjectTags from '$components/projects/ProjectTags.svelte';
@@ -24,16 +24,13 @@
 	<meta property="og:title" content={data.metadata.title} />
 	<meta property="og:description" content={data.metadata.description} />
 	{#if data.metadata.image}
-		<meta property="og:image" content={new URL(data.metadata.image.url, page.url.origin).href} />
+		<meta property="og:image" content={new URL(data.metadata.image.url, Site.url).href} />
 	{/if}
 	<meta property="og:type" content="article" />
 	<meta name="twitter:title" content={data.metadata.title} />
 	<meta name="twitter:description" content={data.metadata.description} />
 	{#if data.metadata.image}
-		<meta
-			name="twitter:image:src"
-			content={new URL(data.metadata.image.url, page.url.origin).href}
-		/>
+		<meta name="twitter:image:src" content={new URL(data.metadata.image.url, Site.url).href} />
 	{/if}
 </svelte:head>
 

--- a/src/routes/tutorials/[slug]/+page.svelte
+++ b/src/routes/tutorials/[slug]/+page.svelte
@@ -2,8 +2,8 @@
 	import { formatDate } from '$lib/utils/date';
 	import type { TutorialPageData } from '$lib/content/tutorials';
 	import '$lib/styles/content.css';
-	import { page } from '$app/state';
 	import { getRandomAccentColor } from '$lib/stores/theme';
+	import Site from '$lib/config/common';
 
 	let { data }: { data: TutorialPageData } = $props();
 
@@ -30,16 +30,13 @@
 	<meta property="og:title" content={data.metadata.title} />
 	<meta property="og:description" content={data.metadata.description} />
 	{#if data.metadata.image}
-		<meta property="og:image" content={new URL(data.metadata.image.url, page.url.origin).href} />
+		<meta property="og:image" content={new URL(data.metadata.image.url, Site.url).href} />
 	{/if}
 	<meta property="og:type" content="article" />
 	<meta name="twitter:title" content={data.metadata.title} />
 	<meta name="twitter:description" content={data.metadata.description} />
 	{#if data.metadata.image}
-		<meta
-			name="twitter:image:src"
-			content={new URL(data.metadata.image.url, page.url.origin).href}
-		/>
+		<meta name="twitter:image:src" content={new URL(data.metadata.image.url, Site.url).href} />
 	{/if}
 </svelte:head>
 


### PR DESCRIPTION
## What changed

- Replaced `page.url.origin` with configured `Site.url` for post, project, and tutorial social image meta tags.
- This prevents prerendered pages from baking `http://sveltekit-prerender/...` into `og:image` and `twitter:image:src`.

## Root cause

SvelteKit prerender runs with a synthetic origin (`http://sveltekit-prerender`). The Caddy Defender page deployed with `og:image` set to `http://sveltekit-prerender/projects/caddy-defender.webp`, so social previews could not resolve the image even though `/projects/caddy-defender.webp` itself was deployed.

## Validation

- Checked production: `/projects/caddy-defender` was deployed at commit `7c16c11`, but its social image meta tags used the bad prerender origin.
- Ran `make build` successfully.
- Verified `.svelte-kit/output/prerendered/pages/projects/caddy-defender.html` now contains `https://jasoncameron.dev/projects/caddy-defender.webp` for both `og:image` and `twitter:image:src`.